### PR TITLE
Updated Ultrasonic sensor to wait 10 microseconds

### DIFF
--- a/SenseBoxMCU.cpp
+++ b/SenseBoxMCU.cpp
@@ -885,7 +885,7 @@ long Ultrasonic::getDistance(void)
 	digitalWrite(_rx, LOW);
 	delayMicroseconds(2);
 	digitalWrite(_rx, HIGH);
-	delayMicroseconds(5);
+	delayMicroseconds(10);
 	digitalWrite(_rx, LOW);
 	pinMode(_tx, INPUT);
 	long duration;


### PR DESCRIPTION
The data sheet of the HCSR04 states to wait 10 microseconds

https://cdn.sparkfun.com/datasheets/Sensors/Proximity/HCSR04.pdf

"You only need to supply a short 10uS pulse to the trigger input to start the ranging, and then the module will send out an 8 cycle burst of ultrasound at 40 kHz and raise its echo."

Is there a reasoning for using 5 ? Waiting 10uS seems more reliable and noise resistant to me than 5uS